### PR TITLE
Allow "smart" eqeqeq

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const defaults = {
         'block-scoped-var': 2,
         'curly': 2,
         'dot-notation': 2,
-        'eqeqeq': 2,
+        'eqeqeq': [2, "smart"],
         'guard-for-in': 2,
         'no-alert': 2,
         'no-caller': 2,

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const defaults = {
         'no-div-regex': 2,
         'no-else-return': 2,
         'no-empty-label': 2,
-        'no-eq-null': 2,
+        'no-eq-null': 0,
         'no-eval': 2,
         'no-extend-native': 0,
         'no-extra-bind': 2,


### PR DESCRIPTION
Please consider allowing smart eqeqeq.

From the [eslint docs](http://eslint.org/docs/rules/eqeqeq):
This option enforces the use of `===` and `!==` except for these cases:
- Comparing two literal values
- Evaluating the value of typeof
- Comparing against null

The following patterns are not considered problems:

```
/* eslint eqeqeq: [2, "smart"] */

typeof foo == 'undefined'
'hello' != 'world'
0 == 0
true == true
foo == null
```

The following patterns are considered problems with "smart":

```
/* eslint eqeqeq: [2, "smart"] */

// comparing two variables requires ===
a == b              /*error Expected '===' and instead saw '=='.*/

// only one side is a literal
foo == true         /*error Expected '===' and instead saw '=='.*/
bananas != 1        /*error Expected '!==' and instead saw '!='.*/

// comparing to undefined requires ===
value == undefined  /*error Expected '===' and instead saw '=='.*/
```
