### PR TITLE
Added keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "test:spt": "cd packages/eslint-config-spt && npm test",
     "test:spt-react": "cd packages/eslint-config-spt-react && npm test"
   },
+  "keywords": [
+    "eslint",
+    "eslintconfig"
+  ],
   "author": {
     "name": "Jason Ellison",
     "email": "code@nosilleg.com"


### PR DESCRIPTION
Per [eslint](http://eslint.org/docs/developer-guide/shareable-configs) recommendation:

> We recommend using the eslint and eslintconfig keywords so others can easily find your module.